### PR TITLE
fixed subscribe invalid query return code

### DIFF
--- a/lensesio/data/data_subscribe.py
+++ b/lensesio/data/data_subscribe.py
@@ -147,7 +147,7 @@ class DataSubscribe():
                 "sqls": [query]
             }
         else:
-            return dataFunc("Error. Please provide either a query(type str) or a list of queries [q1, ...]")
+            return "Error. Please provide either a query (type str) or a list of queries [q1, ...]"
 
         request = {
             "type": "SUBSCRIBE",


### PR DESCRIPTION
Remove dataFunc from return. This function can invoke workload, hence it is not necessary to return failed subscription