### PR TITLE
auto commit disable

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -2,6 +2,10 @@
 
 List of objectives for lensesio pylib
 
+## Bugs
+
+Subscribing creates a continuous query but does not list the client as a subscriber. This blocks any auto-commits
+
 ## Update
 
 **Subscribe method should support Queues**

--- a/lensesio/data/data_subscribe.py
+++ b/lensesio/data/data_subscribe.py
@@ -165,12 +165,14 @@ class DataSubscribe():
                 if bucket['type'] == 'KAFKAMSG':
                     for message in bucket['content']:
                         dataFunc(message)
-
-                    self.Commit(
-                        payload=bucket,
-                        token=self.wc_conn_token,
-                        clientId=bucket['correlationId']
-                    )
+## Auto commit is disabled for now. We need to switch the websocket request
+## to successfully list the client as a subscriber in order for auto-commit to work
+## Part of ToDo 
+#                     self.Commit(
+#                         payload=bucket,
+#                         token=self.wc_conn_token,
+#                         clientId=bucket['correlationId']
+#                     )
                 elif bucket['type'] in ['HEARTBEAT', 'SUCCESS']:
                     dataFunc(bucket)
 


### PR DESCRIPTION
self.Commit() needs an active subscriber. Current websocket method created an continuous query but is not listing the client as a subscriber.
