### PR TITLE
SQL now can be executed as a thread with a queue or directly

### DIFF
--- a/lensesio/data/sql.py
+++ b/lensesio/data/sql.py
@@ -23,7 +23,7 @@ class SQLExec:
             'x-kafka-lenses-token': self.token
         }
 
-        self.active_threads = active_threads
+        self.sql_active_threads = active_threads
 
     def ValidateSqlQuery(self):
         self.validateSqlQuery = exec_request(
@@ -51,16 +51,16 @@ class SQLExec:
                 daemon=False
             )
 
-            self.active_threads['thread_lock'].acquire()
-            self.active_threads['sql']['t'] += 1
-            t = self.active_threads['sql']['t']
-            self.active_threads['sql'][t] = {
+            self.sql_active_threads['thread_lock'].acquire()
+            self.sql_active_threads['sql']['t'] += 1
+            t = self.sql_active_threads['sql']['t']
+            self.sql_active_threads['sql'][t] = {
                 'query': query,
                 'sqlQue': sqlQue,
                 'stats': stats,
             }
 
-            self.active_threads['thread_lock'].release()
+            self.sql_active_threads['thread_lock'].release()
             self.new_sql.start()
 
             print(

--- a/lensesio/data/sql.py
+++ b/lensesio/data/sql.py
@@ -1,7 +1,7 @@
 from lensesio.core.endpoints import getEndpoints
 from lensesio.core.exec_action import exec_request
 from threading import Thread, enumerate, RLock
-from queue import Queue
+import queue
 import inspect
 import json
 import sys
@@ -25,43 +25,63 @@ class SQLExec:
 
         self.sql_active_threads = active_threads
 
-    def ValidateSqlQuery(self):
-        self.validateSqlQuery = exec_request(
-            __METHOD="get",
-            __EXPECTED="text",
-            __URL=self.lenses_sql_query_validation,
-            __HEADERS=self.active_headers,
-            __DATA=self.params,
-            __VERIFY=self.verify_cert
-        )
+    def stop_sql(self, t, stop=False):
+        if stop and self.sql_active_threads['sql'][t]['state']:
+            print("SQL Thread has been marked for shutdown")
+            self.sql_active_threads['sql'][t]['state'] = False
 
-        if 'Expected one of Alter' in self.validateSqlQuery:
-            raise Exception(self.validateSqlQuery.text)
+        self.sql_state_report(t)
+    
+    def sql_state_report(self, t):
+        sqlthread = self.sql_active_threads['sql'][t]['thread']
+        if self.sql_active_threads['sql'][t]['state'] and sqlthread.is_alive():
+            msg = "SQL Thread is running"
+        elif not self.sql_active_threads['sql'][t]['state'] and sqlthread.is_alive():
+            msg = "Waiting for thread to shutdown"
+        else:
+            msg = "SQL Thread has closed"
+
+        return msg, self.sql_active_threads['sql'][t]['state']
+
+    def consume_sql_queue(self, t):
+        try:
+            data = self.sql_active_threads['sql'][t]['sqlQue'].get(block=False)
+            return data
+        except queue.Empty:
+            return "Empty Queue"
 
     def SQL(self, query, spawn_thread=None, stats=0):
         if spawn_thread:
-            sqlQue=Queue()
+
+            self.sql_active_threads['thread_lock'].acquire()
+            self.sql_active_threads['sql']['t'] += 1
+            t = self.sql_active_threads['sql']['t']
+            self.sql_active_threads['thread_lock'].release()
+
+            sqlQue=queue.Queue()
             self.new_sql = Thread(
                 target=self.ExecSQL,
                 args=(
                     query,
                     stats,
                     sqlQue,
+                    t,
                 ),
                 daemon=False
             )
 
             self.sql_active_threads['thread_lock'].acquire()
-            self.sql_active_threads['sql']['t'] += 1
-            t = self.sql_active_threads['sql']['t']
             self.sql_active_threads['sql'][t] = {
                 'query': query,
                 'sqlQue': sqlQue,
                 'stats': stats,
+                "state": False,
+                "state_info": None,
+                "thread": self.new_sql
             }
 
-            self.sql_active_threads['thread_lock'].release()
             self.new_sql.start()
+            self.sql_active_threads['thread_lock'].release()
 
             print(
                 "SQL Thread -\t with SQL_ID: %s has been started\n" % t,
@@ -72,11 +92,11 @@ class SQLExec:
                 "\tcallers_name.active_theads['sql'][SQL_ID]['sqlQueu'].get(block=True, timeout=5)\n"
             )
         elif spawn_thread is None:
-            self.execSQL = self.ExecSQL(query, stats, sqlQue=None)
+            self.execSQL = self.ExecSQL(query, stats, sqlQue=None, t=None)
             return self.execSQL
 
 
-    def ExecSQL(self, query, stats=0, sqlQue=None):
+    def ExecSQL(self, query, stats=0, sqlQue=None, t=None):
         """
 
         :param is_live:
@@ -84,9 +104,14 @@ class SQLExec:
         :return: In case is_extract if false return a dictionary,
         otherwise return Pandas dataframe
         """
+        def update_thread_state(msg):
+            if sqlQue:
+                self.sql_active_threads['sql'][t]['state'] = True
+                self.sql_active_threads['sql'][t]['state'] = msg
+
+        update_thread_state("Started")
         self.query = query
         self.params = {'sql': self.query}
-        self.ValidateSqlQuery()
 
         if 'https' in self.lenses_exec_sql_endpoint:
             self.lenses_exec_sql_endpoint = self.lenses_exec_sql_endpoint.replace(
@@ -107,6 +132,7 @@ class SQLExec:
                 sslopt={"cert_reqs": ssl.CERT_NONE}
             )
 
+        update_thread_state("Created websocket client")
         message = {
             "token": self.token,
             "sql": self.query,
@@ -114,7 +140,7 @@ class SQLExec:
 
         try:
             conn.send(json.dumps(message))
-
+            update_thread_state("Executing query")
             data_list = []
             stats_list = []
             sql_metadata = []
@@ -151,10 +177,13 @@ class SQLExec:
 
             if sqlQue:
                 sqlQue.put(execSQL)
+                update_thread_state("Query execution finished successfully")
             else:
                 return execSQL
         except KeyboardInterrupt:
+            update_thread_state("")
             conn.close()
         except:
+            update_thread_state(str(sys.exc_info()[0]))
             conn.close()
             raise

--- a/lensesio/lenses.py
+++ b/lensesio/lenses.py
@@ -1,24 +1,36 @@
 #!/usr/bin/env python3
 
+
+from lensesio.data.data_subscribe import DataSubscribe
+from lensesio.pulsar.pulsar_client import SetupPulsar
 from lensesio.core.exception import lenses_exception
-from lensesio.core.admin import AdminPanel
-from lensesio.core.basic_auth import Basic
-from lensesio.kafka.topics import KafkaTopic
 from lensesio.registry.schemas import SchemaRegistry
-from lensesio.data.sql import SQLExec
-from lensesio.kafka.quotas import KafkaQuotas
-from lensesio.data.policy import Policy
 from lensesio.data.processors import DataProcessor
 from lensesio.data.connectors import DataConnector
-from lensesio.kafka.acls import KafkaACL
-from lensesio.data.data_subscribe import DataSubscribe
 from lensesio.data.consumers import DataConsumers
-from lensesio.data.topology import Topology
+from threading import Thread, enumerate, RLock
+from lensesio.kafka.quotas import KafkaQuotas
 from lensesio.flows.flows import LensesFlows
-from lensesio.pulsar.pulsar_client import SetupPulsar
-from sys import exit
+from lensesio.kafka.topics import KafkaTopic
+from lensesio.data.topology import Topology
+from lensesio.core.admin import AdminPanel
+from lensesio.core.basic_auth import Basic
+from lensesio.kafka.acls import KafkaACL
+from lensesio.data.policy import Policy
+from lensesio.data.sql import SQLExec
 from sys import modules as sys_mods
+from sys import exit
 import platform
+
+
+ThreadLock = RLock()
+
+active_threads = {
+    'sql': {
+        "t": 0,
+    },
+    "thread_lock": ThreadLock
+}
 
 
 class main(
@@ -99,7 +111,7 @@ class main(
         Topology.__init__(self, verify_cert=verify_cert)
         KafkaTopic.__init__(self, verify_cert=verify_cert)
         SchemaRegistry.__init__(self, verify_cert=verify_cert)
-        SQLExec.__init__(self, verify_cert=verify_cert)
+        SQLExec.__init__(self,  active_threads=active_threads, verify_cert=verify_cert)
         KafkaQuotas.__init__(self, verify_cert=verify_cert)
         Policy.__init__(self, verify_cert=verify_cert)
         DataProcessor.__init__(self, verify_cert=verify_cert)

--- a/lensesio/lenses.py
+++ b/lensesio/lenses.py
@@ -52,6 +52,8 @@ class main(
         if auth_type is None:
             return
 
+        self.active_threads = active_threads
+
         try:
             if auth_type not in ['basic', 'service', 'krb5']:
                 print('''


### PR DESCRIPTION
- SQL methods now can be invoked  directly or spawned as threads.
Each thread has it's own queue which will use to dump results that is getting from Lenses.

The user can get information about the thread via 
`.active_threads['sql'][SQL_ID]`
 and can consume the queue normally as would in any other case: 
`callers_name.active_theads['sql'][SQL_ID]['sqlQueu'].get(block=True, timeout=5)`