### PR TITLE
Subscribe now has thread options.

### DIFF
--- a/lensesio/data/data_subscribe.py
+++ b/lensesio/data/data_subscribe.py
@@ -330,7 +330,7 @@ class DataSubscribe():
         try:
             while self.running_state:
                 bucket = json.loads(ws_con.recv())
-                print(bucket)
+
                 if bucket['type'] == 'KAFKAMSG':
                     for message in bucket['content']:
                         dataFunc(message)

--- a/lensesio/data/data_subscribe.py
+++ b/lensesio/data/data_subscribe.py
@@ -1,11 +1,13 @@
 from lensesio.core.endpoints import getEndpoints
+from threading import Thread, enumerate, RLock
+from sys import exc_info
 import websocket
 import json
 import ssl
 
 class DataSubscribe():
 
-    def __init__(self, service_account=None, verify_cert=True):
+    def __init__(self, active_threads, service_account=None, verify_cert=True):
         getEndpoints.__init__(self, "websocketEndpoints")
 
         self.verify_cert=verify_cert
@@ -23,6 +25,8 @@ class DataSubscribe():
             self.lenses_websocket_endpoint = self.lenses_websocket_endpoint.replace(
                 "http", "ws"
             )
+
+        self.sub_active_threads = active_threads
 
     def _Login(self, clientId):
         if self.auth_type == 'krb5':
@@ -171,7 +175,120 @@ class DataSubscribe():
 
         return self.commit
 
-    def Subscribe(self, dataFunc, query, clientId=1):
+    def stop_subscribe_query(self, t, stop=False):
+        sqlthread = self.sub_active_threads['subscribe'][t]['thread']
+        if not sqlthread.is_alive():
+            self.sub_active_threads['subscribe'][t]['state'] = False
+            return self.subscribe_state_report(t)
+
+        if stop and self.sub_active_threads['subscribe'][t]['state']:
+            print("Subscribe Thread has been marked for shutdown")
+            self.sub_active_threads['subscribe'][t]['state'] = False
+            self.running_state = False
+
+        return self.subscribe_state_report(t)
+
+    def subscribe_state_report(self, t):
+        sqlthread = self.sub_active_threads['subscribe'][t]['thread']
+        if self.sub_active_threads['subscribe'][t]['state'] and sqlthread.is_alive():
+            msg = "Subscribe Thread is running"
+        elif not self.sub_active_threads['subscribe'][t]['state'] and sqlthread.is_alive():
+            msg = "Waiting for thread to shutdown"
+        else:
+            msg = "Subscribe Thread has closed"
+
+        return msg, self.sub_active_threads['subscribe'][t]['state']
+
+    def Subscribe(self, dataFunc, query, clientId=1, spawn_thread=None):
+        if spawn_thread:
+            self.sub_active_threads['thread_lock'].acquire()
+            self.sub_active_threads['subscribe']['t'] += 1
+            t = self.sub_active_threads['subscribe']['t']
+            self.sub_active_threads['thread_lock'].release()
+
+            self.new_sql = Thread(
+                target=self.exec_subscribe,
+                args=(
+                    dataFunc,
+                    query,
+                    clientId,
+                    t,
+                ),
+                daemon=False
+            )
+
+            self.sub_active_threads['thread_lock'].acquire()
+            self.sub_active_threads['subscribe'][t] = {
+                'dataFunc': dataFunc,
+                'query': query,
+                'clientId': clientId,
+                "state": False,
+                "state_info": None,
+                "thread": self.new_sql,
+                "topic_metadata": {}
+            }
+
+            self.new_sql.start()
+            self.sub_active_threads['thread_lock'].release()
+
+            print(
+                "SQL Thread -\t with SUBSCRIBE_ID: %s has been started\n" % t,
+                "You may find thread info at callers_name.active_threads object\n"
+            )
+        elif not spawn_thread:
+            self.execSQL = self.exec_subscribe(dataFunc, query, clientId, t=None)
+            return self.execSQL
+
+    def exec_subscribe(self, dataFunc, query, clientId=1, t=None):
+        def update_thread_state(msg, state=True):
+            if t:
+                self.sub_active_threads['thread_lock'].acquire()
+                self.sub_active_threads['subscribe'][t]['state'] = state
+                self.sub_active_threads['subscribe'][t]['state_info'] = msg
+
+                if not state:
+                    self.running_state = False
+
+                self.sub_active_threads['thread_lock'].release()
+
+        def update_subscribe_metadata(message):
+            if t:
+                topic = message['topic']
+                partition = message['partition']
+                offset = int(message['offset'])
+
+                self.sub_active_threads['thread_lock'].acquire()
+                if self.sub_active_threads['subscribe'][t]['topic_metadata'].get(topic):
+                    key_exists = self.sub_active_threads['subscribe'][t][
+                        'topic_metadata'
+                    ][topic]["partitions"].get(partition)
+                    if key_exists:
+                        self.sub_active_threads['subscribe'][t][
+                            'topic_metadata'
+                        ][topic]["partitions"][partition]["offset"] = offset
+                    else:
+                        self.sub_active_threads['subscribe'][t][
+                            'topic_metadata'
+                        ][topic]["partitions"][partition] = {
+                            "offset": offset
+                        }
+
+                    self.sub_active_threads['subscribe'][t]['topic_metadata'][topic]["total_records"] += 1
+
+                else:
+                    self.sub_active_threads['subscribe'][t]['topic_metadata'][topic] = {
+                        "partitions": {
+                            partition: {
+                                "offset": offset
+                            }
+                        },
+                        "total_records": 1
+                    }
+
+                self.sub_active_threads['thread_lock'].release()
+
+        update_thread_state("Started")
+        self.running_state = True
         if self.service_account:
             self.wc_conn_token == self.service_account
             self.url_req = self.lenses_websocket_endpoint + str(clientId)
@@ -206,14 +323,18 @@ class DataSubscribe():
                 sslopt={"cert_reqs": ssl.CERT_NONE}
             )
 
+        update_thread_state("Created websocket client")
         ws_con.send(json.dumps(request))
-        try:
-            while True:
-                bucket = json.loads(ws_con.recv())
+        update_thread_state("Executing query")
 
+        try:
+            while self.running_state:
+                bucket = json.loads(ws_con.recv())
+                print(bucket)
                 if bucket['type'] == 'KAFKAMSG':
                     for message in bucket['content']:
                         dataFunc(message)
+                        update_subscribe_metadata(message)
                     # # Auto commit is disabled for now. We need to switch the websocket request
                     # # to successfully list the client as a subscriber in order for auto-commit to work
                     # # Part of ToDo 
@@ -224,10 +345,18 @@ class DataSubscribe():
                     # )
                 elif bucket['type'] in ['HEARTBEAT', 'SUCCESS']:
                     dataFunc(bucket)
+                elif bucket['type'] in ['ERROR']:
+                    update_thread_state(bucket['content'], False)
 
             ws_con.close()
+            update_thread_state("Subscribe query execution finished successfully", False)
         except KeyboardInterrupt:
+            update_thread_state("")
             ws_con.close()
+        except:
+            ws_con.close()
+            update_thread_state(str(exc_info()), False)
+            raise
 
     def Unsubscribe(self, topic, clientId=1):
         if self.service_account:

--- a/lensesio/lenses.py
+++ b/lensesio/lenses.py
@@ -29,6 +29,9 @@ active_threads = {
     'sql': {
         "t": 0,
     },
+    'subscribe': {
+        "t": 0,
+    },
     "thread_lock": ThreadLock
 }
 
@@ -113,13 +116,13 @@ class main(
         Topology.__init__(self, verify_cert=verify_cert)
         KafkaTopic.__init__(self, verify_cert=verify_cert)
         SchemaRegistry.__init__(self, verify_cert=verify_cert)
-        SQLExec.__init__(self,  active_threads=active_threads, verify_cert=verify_cert)
+        SQLExec.__init__(self, active_threads=active_threads, verify_cert=verify_cert)
         KafkaQuotas.__init__(self, verify_cert=verify_cert)
         Policy.__init__(self, verify_cert=verify_cert)
         DataProcessor.__init__(self, verify_cert=verify_cert)
         DataConnector.__init__(self, verify_cert=verify_cert)
         KafkaACL.__init__(self, verify_cert=verify_cert)
-        DataSubscribe.__init__(self, service_account=service_account, verify_cert=verify_cert)
+        DataSubscribe.__init__(self, active_threads=active_threads, service_account=service_account, verify_cert=verify_cert)
         DataConsumers.__init__(self, verify_cert=verify_cert)
 
     def InitPulsarClient(self, host):


### PR DESCRIPTION
- Update: now sql consume returns a set of (data/err, True/False)
- Update: Subscribe method has thread option

Each subscribe thread provides information for the thread status:
- SQL Query status
- Thread running state
- Topics consumed
- Partitions & offsets per topic
- Total records consumed per topic
- Data function related with subscription thread

In addition to that, subscribe threads can be accessed via `caller.active_threads[......][SUB_ID]`,
runtime info can be exported via `subscribe_state_report` and can be gracefully shutdown via `stop_subscribe_query`